### PR TITLE
chore(ci): remove semrel git and changelog

### DIFF
--- a/release.config.js
+++ b/release.config.js
@@ -9,24 +9,9 @@ module.exports = {
     '@semantic-release/commit-analyzer',
     '@semantic-release/release-notes-generator',
     [
-      '@semantic-release/changelog',
-      {
-        changelogFile: 'CHANGELOG.md',
-        changelogTitle: '# Changelog',
-      },
-    ],
-    [
       '@semantic-release/npm',
       {
         npmPublish: false,
-        pkgRoot: '.', // bump the root package.json version
-      },
-    ],
-    [
-      '@semantic-release/git',
-      {
-        assets: ['CHANGELOG.md', 'package.json'],
-        message: 'chore(release): ${nextRelease.version}\n\n${nextRelease.notes}',
       },
     ],
     '@semantic-release/github',


### PR DESCRIPTION
## Summary

Removed git/changelog semrel to allow for branch protection.

## Why

Enables branch protection.

## Test plan

## Screenshots (if UI)

## Risk & rollback

## Notes

