### PR TITLE
feat(staging): implement Capture & Staging Area with per-item actions

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,14 +1,15 @@
 // apps/web/src/App.tsx
 import { useState, useEffect } from 'react';
-import reactLogo from './assets/react.svg';
-import viteLogo from '/vite.svg';
 import './App.css';
 
 import NodesPage from './pages/NodesPage';
+import StagingPage from './pages/StagingPage';
 import { ensureSchema } from './data/db';
 
+type Page = 'nodes' | 'staging';
+
 function App() {
-  const [count, setCount] = useState(0);
+  const [page, setPage] = useState<Page>('nodes');
 
   useEffect(() => {
     // Ensure DB schema (nodes + staging_items) is created on startup
@@ -18,30 +19,20 @@ function App() {
   }, []);
 
   return (
-    <>
-      <div>
-        <a href="https://vite.dev" target="_blank" rel="noreferrer">
-          <img src={viteLogo} className="logo" alt="Vite logo" />
-        </a>
-        <a href="https://react.dev" target="_blank" rel="noreferrer">
-          <img src={reactLogo} className="logo react" alt="React logo" />
-        </a>
-      </div>
+    <div>
+      <header style={{ display: 'flex', gap: 8, padding: 8, borderBottom: '1px solid #ddd' }}>
+        <button onClick={() => setPage('nodes')} disabled={page === 'nodes'}>
+          Nodes
+        </button>
+        <button onClick={() => setPage('staging')} disabled={page === 'staging'}>
+          Staging
+        </button>
+      </header>
 
-      <h1>Vite + React</h1>
-
-      <div className="card">
-        <button onClick={() => setCount((c) => c + 1)}>count is {count}</button>
-        <p>
-          Edit <code>src/App.tsx</code> and save to test HMR
-        </p>
-      </div>
-
-      <p className="read-the-docs">Click on the Vite and React logos to learn more</p>
-
-      {/* Mount NodesPage so its useEffect runs initSqlite() */}
-      <NodesPage />
-    </>
+      <main>
+        {page === 'nodes' ? <NodesPage /> : <StagingPage />}
+      </main>
+    </div>
   );
 }
 

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,13 +1,21 @@
 // apps/web/src/App.tsx
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import reactLogo from './assets/react.svg';
 import viteLogo from '/vite.svg';
 import './App.css';
 
 import NodesPage from './pages/NodesPage';
+import { ensureSchema } from './data/db';
 
 function App() {
   const [count, setCount] = useState(0);
+
+  useEffect(() => {
+    // Ensure DB schema (nodes + staging_items) is created on startup
+    ensureSchema().catch((err) => {
+      console.error('Failed to ensure schema:', err);
+    });
+  }, []);
 
   return (
     <>

--- a/apps/web/src/components/CaptureForm.tsx
+++ b/apps/web/src/components/CaptureForm.tsx
@@ -1,0 +1,67 @@
+// apps/web/src/components/CaptureForm.tsx
+import { useState } from 'react';
+
+interface CaptureFormProps {
+  titlePlaceholder?: string;
+  bodyPlaceholder?: string;
+  disabled?: boolean;
+  onSubmit: (title: string, body?: string) => Promise<void> | void;
+}
+
+export default function CaptureForm({
+  titlePlaceholder = 'Title…',
+  bodyPlaceholder = 'Body (optional)…',
+  disabled = false,
+  onSubmit,
+}: CaptureFormProps) {
+  const [title, setTitle] = useState('');
+  const [body, setBody] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    const t = title.trim();
+    const b = body.trim();
+    if (!t) return;
+    setSubmitting(true);
+    try {
+      await onSubmit(t, b || undefined);
+      setTitle('');
+      setBody('');
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <form onSubmit={handleSubmit} style={{ display: 'grid', gap: 8, marginBottom: 12 }}>
+      <input
+        type="text"
+        placeholder={titlePlaceholder}
+        value={title}
+        onChange={(e) => setTitle(e.target.value)}
+        disabled={disabled || submitting}
+        style={{ padding: 8 }}
+        aria-label="Title"
+      />
+      <textarea
+        placeholder={bodyPlaceholder}
+        value={body}
+        onChange={(e) => setBody(e.target.value)}
+        disabled={disabled || submitting}
+        rows={3}
+        style={{ padding: 8, resize: 'vertical' }}
+        aria-label="Body"
+      />
+      <div style={{ display: 'flex', gap: 8 }}>
+        <button
+          type="submit"
+          disabled={disabled || submitting || !title.trim()}
+          style={{ padding: '8px 12px' }}
+        >
+          {submitting ? 'Adding…' : 'Add'}
+        </button>
+      </div>
+    </form>
+  );
+}

--- a/apps/web/src/components/NodeItem.tsx
+++ b/apps/web/src/components/NodeItem.tsx
@@ -1,0 +1,50 @@
+// apps/web/src/components/NodeItem.tsx
+interface NodeItemProps {
+  id: number;
+  title: string;
+  body?: string;
+  createdAt: Date;
+  onDelete: (id: number) => void;
+  isDeleting: boolean;
+}
+
+export default function NodeItem({
+  id,
+  title,
+  body,
+  createdAt,
+  onDelete,
+  isDeleting,
+}: NodeItemProps) {
+  return (
+    <li
+      style={{
+        padding: 12,
+        border: '1px solid rgba(0,0,0,0.1)',
+        borderRadius: 8,
+        display: 'grid',
+        gap: 6,
+      }}
+    >
+      <div style={{ display: 'flex', alignItems: 'baseline', justifyContent: 'space-between', gap: 12 }}>
+        <div style={{ minWidth: 0, flex: 1 }}>
+          <div style={{ fontWeight: 600, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+            {title}
+          </div>
+          <div style={{ fontSize: 12, opacity: 0.7 }}>{createdAt.toLocaleString()}</div>
+        </div>
+        <button
+          onClick={() => onDelete(id)}
+          disabled={isDeleting}
+          style={{ padding: '6px 10px' }}
+          aria-label={`Delete ${title}`}
+        >
+          {isDeleting ? 'Deleting…' : 'Delete'}
+        </button>
+      </div>
+      {body ? (
+        <div style={{ whiteSpace: 'pre-wrap', wordBreak: 'break-word' }}>{body}</div>
+      ) : null}
+    </li>
+  );
+}

--- a/apps/web/src/components/PersistencePill.tsx
+++ b/apps/web/src/components/PersistencePill.tsx
@@ -1,0 +1,20 @@
+// apps/web/src/components/PersistencePill.tsx
+import { usePersistenceMode } from '../hooks/usePersistenceMode';
+
+export default function PersistencePill() {
+  const mode = usePersistenceMode();
+
+  const pillStyle: React.CSSProperties = {
+    padding: '2px 8px',
+    borderRadius: 999,
+    fontSize: 12,
+    border: '1px solid rgba(0,0,0,0.15)',
+    background: 'rgba(0,0,0,0.03)',
+  };
+
+  return (
+    <span style={pillStyle}>
+      Persistence: {mode ?? '…'}
+    </span>
+  );
+}

--- a/apps/web/src/components/StagingItem.tsx
+++ b/apps/web/src/components/StagingItem.tsx
@@ -1,0 +1,45 @@
+// apps/web/src/components/StagingItem.tsx
+import type { StagingItemRow } from '../data/staging';
+
+interface StagingItemProps {
+  item: StagingItemRow;
+  onDiscard: (id: number) => void;
+  isDiscarding: boolean;
+}
+
+export default function StagingItem({ item, onDiscard, isDiscarding }: StagingItemProps) {
+  return (
+    <li
+      style={{
+        padding: 12,
+        border: '1px solid rgba(0,0,0,0.1)',
+        borderRadius: 8,
+        display: 'flex',
+        flexDirection: 'column',
+        gap: 6,
+      }}
+    >
+      <div style={{ display: 'flex', alignItems: 'baseline', justifyContent: 'space-between', gap: 12 }}>
+        <div style={{ minWidth: 0, flex: 1 }}>
+          <div style={{ fontWeight: 600, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+            {item.title || '(untitled)'}
+          </div>
+          <div style={{ fontSize: 12, opacity: 0.7 }}>
+            {item.kind} • {new Date(item.createdAt).toLocaleString()}
+          </div>
+        </div>
+        <button
+          onClick={() => onDiscard(item.id)}
+          disabled={isDiscarding}
+          style={{ padding: '6px 10px' }}
+          aria-label={`Discard ${item.title ?? 'staging item'}`}
+        >
+          {isDiscarding ? 'Discarding…' : 'Discard'}
+        </button>
+      </div>
+      {item.content ? (
+        <div style={{ whiteSpace: 'pre-wrap', wordBreak: 'break-word' }}>{item.content}</div>
+      ) : null}
+    </li>
+  );
+}

--- a/apps/web/src/components/StagingItem.tsx
+++ b/apps/web/src/components/StagingItem.tsx
@@ -7,8 +7,10 @@ interface StagingItemProps {
   onDiscard: (id: number) => void;
   onFile: (id: number) => void;
   onUpdateTags: (id: number, tags: string[]) => Promise<void>;
+  onSummarize: (id: number) => Promise<void>;
   isDiscarding: boolean;
   isFiling: boolean;
+  isSummarizing: boolean;
 }
 
 export default function StagingItem({
@@ -16,11 +18,14 @@ export default function StagingItem({
   onDiscard,
   onFile,
   onUpdateTags,
+  onSummarize,
   isDiscarding,
   isFiling,
+  isSummarizing,
 }: StagingItemProps) {
   const [tagInput, setTagInput] = useState('');
   const tags: string[] = item.tags ? JSON.parse(item.tags) : [];
+  const meta = item.meta ? JSON.parse(item.meta) : {};
 
   async function addTag(e: React.FormEvent) {
     e.preventDefault();
@@ -66,6 +71,14 @@ export default function StagingItem({
             {isFiling ? 'Filing…' : 'File'}
           </button>
           <button
+            onClick={() => onSummarize(item.id)}
+            disabled={isSummarizing}
+            style={{ padding: '6px 10px' }}
+            aria-label={`Summarize ${item.title ?? 'staging item'}`}
+          >
+            {isSummarizing ? 'Summarizing…' : 'Summarize'}
+          </button>
+          <button
             onClick={() => onDiscard(item.id)}
             disabled={isDiscarding}
             style={{ padding: '6px 10px' }}
@@ -78,6 +91,13 @@ export default function StagingItem({
 
       {item.content ? (
         <div style={{ whiteSpace: 'pre-wrap', wordBreak: 'break-word' }}>{item.content}</div>
+      ) : null}
+
+      {/* Show summary if present */}
+      {meta.summary ? (
+        <div style={{ fontStyle: 'italic', fontSize: 13, background: 'rgba(0,0,0,0.03)', padding: 6, borderRadius: 6 }}>
+          Summary: {meta.summary}
+        </div>
       ) : null}
 
       {/* Tags */}

--- a/apps/web/src/components/StagingItem.tsx
+++ b/apps/web/src/components/StagingItem.tsx
@@ -2,12 +2,19 @@
 import { useState } from 'react';
 import type { StagingItemRow } from '../data/staging';
 
+interface NodeSummary {
+  id: number;
+  title: string;
+}
+
 interface StagingItemProps {
   item: StagingItemRow;
+  availableNodes: NodeSummary[];
   onDiscard: (id: number) => void;
   onFile: (id: number) => void;
   onUpdateTags: (id: number, tags: string[]) => Promise<void>;
   onSummarize: (id: number) => Promise<void>;
+  onUpdateLinks: (id: number, links: number[]) => Promise<void>;
   isDiscarding: boolean;
   isFiling: boolean;
   isSummarizing: boolean;
@@ -15,17 +22,22 @@ interface StagingItemProps {
 
 export default function StagingItem({
   item,
+  availableNodes,
   onDiscard,
   onFile,
   onUpdateTags,
   onSummarize,
+  onUpdateLinks,
   isDiscarding,
   isFiling,
   isSummarizing,
 }: StagingItemProps) {
   const [tagInput, setTagInput] = useState('');
+  const [selectedNodeId, setSelectedNodeId] = useState<number | ''>('');
+
   const tags: string[] = item.tags ? JSON.parse(item.tags) : [];
   const meta = item.meta ? JSON.parse(item.meta) : {};
+  const links: number[] = meta.links ?? [];
 
   async function addTag(e: React.FormEvent) {
     e.preventDefault();
@@ -39,6 +51,19 @@ export default function StagingItem({
   async function removeTag(tag: string) {
     const newTags = tags.filter((t) => t !== tag);
     await onUpdateTags(item.id, newTags);
+  }
+
+  async function addLink(e: React.FormEvent) {
+    e.preventDefault();
+    if (!selectedNodeId) return;
+    const newLinks = [...links, selectedNodeId];
+    await onUpdateLinks(item.id, newLinks);
+    setSelectedNodeId('');
+  }
+
+  async function removeLink(nodeId: number) {
+    const newLinks = links.filter((id) => id !== nodeId);
+    await onUpdateLinks(item.id, newLinks);
   }
 
   return (
@@ -66,7 +91,6 @@ export default function StagingItem({
             onClick={() => onFile(item.id)}
             disabled={isFiling}
             style={{ padding: '6px 10px' }}
-            aria-label={`File ${item.title ?? 'staging item'}`}
           >
             {isFiling ? 'Filing…' : 'File'}
           </button>
@@ -74,7 +98,6 @@ export default function StagingItem({
             onClick={() => onSummarize(item.id)}
             disabled={isSummarizing}
             style={{ padding: '6px 10px' }}
-            aria-label={`Summarize ${item.title ?? 'staging item'}`}
           >
             {isSummarizing ? 'Summarizing…' : 'Summarize'}
           </button>
@@ -82,7 +105,6 @@ export default function StagingItem({
             onClick={() => onDiscard(item.id)}
             disabled={isDiscarding}
             style={{ padding: '6px 10px' }}
-            aria-label={`Discard ${item.title ?? 'staging item'}`}
           >
             {isDiscarding ? 'Discarding…' : 'Discard'}
           </button>
@@ -93,7 +115,7 @@ export default function StagingItem({
         <div style={{ whiteSpace: 'pre-wrap', wordBreak: 'break-word' }}>{item.content}</div>
       ) : null}
 
-      {/* Show summary if present */}
+      {/* Summary */}
       {meta.summary ? (
         <div style={{ fontStyle: 'italic', fontSize: 13, background: 'rgba(0,0,0,0.03)', padding: 6, borderRadius: 6 }}>
           Summary: {meta.summary}
@@ -101,7 +123,7 @@ export default function StagingItem({
       ) : null}
 
       {/* Tags */}
-      <div style={{ display: 'flex', flexWrap: 'wrap', gap: 6, marginTop: 6 }}>
+      <div style={{ display: 'flex', flexWrap: 'wrap', gap: 6 }}>
         {tags.map((tag) => (
           <span
             key={tag}
@@ -119,14 +141,7 @@ export default function StagingItem({
             {tag}
             <button
               onClick={() => removeTag(tag)}
-              style={{
-                border: 'none',
-                background: 'transparent',
-                cursor: 'pointer',
-                fontSize: 12,
-                padding: 0,
-              }}
-              aria-label={`Remove tag ${tag}`}
+              style={{ border: 'none', background: 'transparent', cursor: 'pointer' }}
             >
               ×
             </button>
@@ -134,7 +149,7 @@ export default function StagingItem({
         ))}
       </div>
 
-      <form onSubmit={addTag} style={{ display: 'flex', gap: 6, marginTop: 6 }}>
+      <form onSubmit={addTag} style={{ display: 'flex', gap: 6 }}>
         <input
           type="text"
           placeholder="Add tag…"
@@ -144,6 +159,54 @@ export default function StagingItem({
         />
         <button type="submit" disabled={!tagInput.trim()} style={{ padding: '6px 10px' }}>
           Add
+        </button>
+      </form>
+
+      {/* Links */}
+      <div style={{ display: 'flex', flexWrap: 'wrap', gap: 6 }}>
+        {links.map((nodeId) => {
+          const node = availableNodes.find((n) => n.id === nodeId);
+          return (
+            <span
+              key={nodeId}
+              style={{
+                display: 'inline-flex',
+                alignItems: 'center',
+                gap: 4,
+                padding: '2px 6px',
+                fontSize: 12,
+                border: '1px solid rgba(0,0,0,0.15)',
+                borderRadius: 999,
+                background: 'rgba(0,0,0,0.05)',
+              }}
+            >
+              {node ? node.title : `Node ${nodeId}`}
+              <button
+                onClick={() => removeLink(nodeId)}
+                style={{ border: 'none', background: 'transparent', cursor: 'pointer' }}
+              >
+                ×
+              </button>
+            </span>
+          );
+        })}
+      </div>
+
+      <form onSubmit={addLink} style={{ display: 'flex', gap: 6 }}>
+        <select
+          value={selectedNodeId}
+          onChange={(e) => setSelectedNodeId(Number(e.target.value))}
+          style={{ flex: 1, padding: 6 }}
+        >
+          <option value="">Select node…</option>
+          {availableNodes.map((node) => (
+            <option key={node.id} value={node.id}>
+              {node.title}
+            </option>
+          ))}
+        </select>
+        <button type="submit" disabled={!selectedNodeId} style={{ padding: '6px 10px' }}>
+          Link
         </button>
       </form>
     </li>

--- a/apps/web/src/components/StagingItem.tsx
+++ b/apps/web/src/components/StagingItem.tsx
@@ -1,10 +1,12 @@
 // apps/web/src/components/StagingItem.tsx
+import { useState } from 'react';
 import type { StagingItemRow } from '../data/staging';
 
 interface StagingItemProps {
   item: StagingItemRow;
   onDiscard: (id: number) => void;
   onFile: (id: number) => void;
+  onUpdateTags: (id: number, tags: string[]) => Promise<void>;
   isDiscarding: boolean;
   isFiling: boolean;
 }
@@ -13,9 +15,27 @@ export default function StagingItem({
   item,
   onDiscard,
   onFile,
+  onUpdateTags,
   isDiscarding,
   isFiling,
 }: StagingItemProps) {
+  const [tagInput, setTagInput] = useState('');
+  const tags: string[] = item.tags ? JSON.parse(item.tags) : [];
+
+  async function addTag(e: React.FormEvent) {
+    e.preventDefault();
+    const t = tagInput.trim();
+    if (!t) return;
+    const newTags = [...tags, t];
+    await onUpdateTags(item.id, newTags);
+    setTagInput('');
+  }
+
+  async function removeTag(tag: string) {
+    const newTags = tags.filter((t) => t !== tag);
+    await onUpdateTags(item.id, newTags);
+  }
+
   return (
     <li
       style={{
@@ -55,9 +75,57 @@ export default function StagingItem({
           </button>
         </div>
       </div>
+
       {item.content ? (
         <div style={{ whiteSpace: 'pre-wrap', wordBreak: 'break-word' }}>{item.content}</div>
       ) : null}
+
+      {/* Tags */}
+      <div style={{ display: 'flex', flexWrap: 'wrap', gap: 6, marginTop: 6 }}>
+        {tags.map((tag) => (
+          <span
+            key={tag}
+            style={{
+              display: 'inline-flex',
+              alignItems: 'center',
+              gap: 4,
+              padding: '2px 6px',
+              fontSize: 12,
+              border: '1px solid rgba(0,0,0,0.15)',
+              borderRadius: 999,
+              background: 'rgba(0,0,0,0.03)',
+            }}
+          >
+            {tag}
+            <button
+              onClick={() => removeTag(tag)}
+              style={{
+                border: 'none',
+                background: 'transparent',
+                cursor: 'pointer',
+                fontSize: 12,
+                padding: 0,
+              }}
+              aria-label={`Remove tag ${tag}`}
+            >
+              ×
+            </button>
+          </span>
+        ))}
+      </div>
+
+      <form onSubmit={addTag} style={{ display: 'flex', gap: 6, marginTop: 6 }}>
+        <input
+          type="text"
+          placeholder="Add tag…"
+          value={tagInput}
+          onChange={(e) => setTagInput(e.target.value)}
+          style={{ flex: 1, padding: 6, fontSize: 14 }}
+        />
+        <button type="submit" disabled={!tagInput.trim()} style={{ padding: '6px 10px' }}>
+          Add
+        </button>
+      </form>
     </li>
   );
 }

--- a/apps/web/src/components/StagingItem.tsx
+++ b/apps/web/src/components/StagingItem.tsx
@@ -4,10 +4,18 @@ import type { StagingItemRow } from '../data/staging';
 interface StagingItemProps {
   item: StagingItemRow;
   onDiscard: (id: number) => void;
+  onFile: (id: number) => void;
   isDiscarding: boolean;
+  isFiling: boolean;
 }
 
-export default function StagingItem({ item, onDiscard, isDiscarding }: StagingItemProps) {
+export default function StagingItem({
+  item,
+  onDiscard,
+  onFile,
+  isDiscarding,
+  isFiling,
+}: StagingItemProps) {
   return (
     <li
       style={{
@@ -28,14 +36,24 @@ export default function StagingItem({ item, onDiscard, isDiscarding }: StagingIt
             {item.kind} • {new Date(item.createdAt).toLocaleString()}
           </div>
         </div>
-        <button
-          onClick={() => onDiscard(item.id)}
-          disabled={isDiscarding}
-          style={{ padding: '6px 10px' }}
-          aria-label={`Discard ${item.title ?? 'staging item'}`}
-        >
-          {isDiscarding ? 'Discarding…' : 'Discard'}
-        </button>
+        <div style={{ display: 'flex', gap: 6 }}>
+          <button
+            onClick={() => onFile(item.id)}
+            disabled={isFiling}
+            style={{ padding: '6px 10px' }}
+            aria-label={`File ${item.title ?? 'staging item'}`}
+          >
+            {isFiling ? 'Filing…' : 'File'}
+          </button>
+          <button
+            onClick={() => onDiscard(item.id)}
+            disabled={isDiscarding}
+            style={{ padding: '6px 10px' }}
+            aria-label={`Discard ${item.title ?? 'staging item'}`}
+          >
+            {isDiscarding ? 'Discarding…' : 'Discard'}
+          </button>
+        </div>
       </div>
       {item.content ? (
         <div style={{ whiteSpace: 'pre-wrap', wordBreak: 'break-word' }}>{item.content}</div>

--- a/apps/web/src/data/db.ts
+++ b/apps/web/src/data/db.ts
@@ -70,6 +70,8 @@ export async function ensureSchema() {
   if (schemaReady) return;
 
   const db = await getDb();
+
+  // Nodes table (already existing)
   db.exec?.(`
     CREATE TABLE IF NOT EXISTS nodes (
       id INTEGER PRIMARY KEY,
@@ -78,6 +80,25 @@ export async function ensureSchema() {
       createdAt INTEGER NOT NULL
     );
   `);
+
+  // New: Staging items table
+  db.exec?.(`
+    CREATE TABLE IF NOT EXISTS staging_items (
+      id INTEGER PRIMARY KEY,
+      kind TEXT NOT NULL CHECK(kind IN ('text','file','url','clipboard')),
+      title TEXT,
+      content TEXT,
+      filePath TEXT,
+      source TEXT NOT NULL CHECK(source IN ('manual','dragdrop','clipboard','import')),
+      tags TEXT,
+      createdAt INTEGER NOT NULL,
+      meta TEXT
+    );
+  `);
+
+  // Helpful indexes for staging_items
+  db.exec?.(`CREATE INDEX IF NOT EXISTS idx_staging_items_createdAt ON staging_items(createdAt DESC);`);
+  db.exec?.(`CREATE INDEX IF NOT EXISTS idx_staging_items_kind ON staging_items(kind);`);
 
   schemaReady = true;
   console.info('[sqlite-wasm] schema ensured');

--- a/apps/web/src/data/staging.ts
+++ b/apps/web/src/data/staging.ts
@@ -1,0 +1,77 @@
+// apps/web/src/data/staging.ts
+import { getDb } from './db';
+
+/**
+ * Exact shape of a row in the staging_items table.
+ * Mirrors the SQLite schema strictly.
+ */
+export interface StagingItemRow {
+  id: number;
+  kind: 'text' | 'file' | 'url' | 'clipboard';
+  title: string | null;
+  content: string | null;
+  filePath: string | null;
+  source: 'manual' | 'dragdrop' | 'clipboard' | 'import';
+  tags: string | null; // JSON string (e.g. '["tag1","tag2"]')
+  createdAt: number;   // ms since epoch
+  meta: string | null; // JSON string (e.g. '{"size":123,"mime":"text/plain"}')
+}
+
+/**
+ * Insert a new staging item.
+ * - Fills in createdAt automatically.
+ * - Returns the inserted row ID.
+ */
+export async function insertStagingItem(
+  item: Omit<StagingItemRow, 'id' | 'createdAt'>
+): Promise<number> {
+  const db = await getDb();
+  const createdAt = Date.now();
+
+  db.exec?.({
+    sql: `
+      INSERT INTO staging_items
+        (kind, title, content, filePath, source, tags, createdAt, meta)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?);
+    `,
+    bind: [
+      item.kind,
+      item.title ?? null,
+      item.content ?? null,
+      item.filePath ?? null,
+      item.source,
+      item.tags ?? null,
+      createdAt,
+      item.meta ?? null,
+    ],
+  });
+
+  // SQLite oo1 API doesn’t return lastInsertRowId directly,
+  // but we can query it in the same connection:
+  const rows = db.selectObjects?.(
+    'SELECT last_insert_rowid() as id;'
+  ) as { id: number }[];
+  return rows[0].id;
+}
+
+/**
+ * List staging items, newest first.
+ */
+export async function listStagingItems(
+  opts: { limit?: number; offset?: number } = {}
+): Promise<StagingItemRow[]> {
+  const db = await getDb();
+  const { limit = 50, offset = 0 } = opts;
+
+  const rows = db.selectObjects?.(
+    `
+      SELECT *
+      FROM staging_items
+      ORDER BY createdAt DESC
+      LIMIT ? OFFSET ?;
+    `,
+    [limit, offset]
+  ) as StagingItemRow[];
+
+  return rows ?? [];
+}

--- a/apps/web/src/data/staging.ts
+++ b/apps/web/src/data/staging.ts
@@ -101,3 +101,29 @@ export async function updateStagingTags(id: number, tags: string[]): Promise<voi
   });
 }
 
+export async function updateStagingSummary(id: number, summary: string): Promise<void> {
+  const db = await getDb();
+
+  // Load current meta JSON (if any)
+  const rows = db.selectObjects?.(
+    `SELECT meta FROM staging_items WHERE id = ?;`,
+    [id]
+  ) as { meta: string | null }[];
+
+  let meta: any = {};
+  if (rows && rows.length > 0 && rows[0].meta) {
+    try {
+      meta = JSON.parse(rows[0].meta);
+    } catch {
+      meta = {};
+    }
+  }
+
+  // Update summary
+  meta.summary = summary;
+
+  db.exec?.({
+    sql: `UPDATE staging_items SET meta = ? WHERE id = ?;`,
+    bind: [JSON.stringify(meta), id],
+  });
+}

--- a/apps/web/src/data/staging.ts
+++ b/apps/web/src/data/staging.ts
@@ -1,11 +1,7 @@
 // apps/web/src/data/staging.ts
-import { getDb } from './db';
+import { getDbAdapter, getWriteAdapter } from './dbAdapter';
 import { addNode } from './nodes';
 
-/**
- * Exact shape of a row in the staging_items table.
- * Mirrors the SQLite schema strictly.
- */
 export interface StagingItemRow {
   id: number;
   kind: 'text' | 'file' | 'url' | 'clipboard';
@@ -13,22 +9,22 @@ export interface StagingItemRow {
   content: string | null;
   filePath: string | null;
   source: 'manual' | 'dragdrop' | 'clipboard' | 'import';
-  tags: string | null; // JSON string (e.g. '["tag1","tag2"]')
-  createdAt: number;   // ms since epoch
-  meta: string | null; // JSON string (e.g. '{"size":123,"mime":"text/plain"}')
+  tags: string | null; // JSON string
+  createdAt: number;
+  meta: string | null; // JSON string
 }
 
 export async function insertStagingItem(
   item: Omit<StagingItemRow, 'id' | 'createdAt'>
-): Promise<number> {
-  const db = await getDb();
+): Promise<void> {
+  const db = await getWriteAdapter();
   const createdAt = Date.now();
 
-  db.exec?.({
+  await db.exec({
     sql: `
       INSERT INTO staging_items
         (kind, title, content, filePath, source, tags, createdAt, meta)
-      VALUES (?, ?, ?, ?, ?, ?, ?, ?);
+      VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)
     `,
     bind: [
       item.kind,
@@ -41,77 +37,60 @@ export async function insertStagingItem(
       item.meta ?? null,
     ],
   });
-
-  const rows = db.selectObjects?.(
-    'SELECT last_insert_rowid() as id;'
-  ) as { id: number }[];
-  return rows[0].id;
 }
 
 export async function listStagingItems(
   opts: { limit?: number; offset?: number } = {}
 ): Promise<StagingItemRow[]> {
-  const db = await getDb();
+  const db = await getDbAdapter();
   const { limit = 50, offset = 0 } = opts;
 
-  const rows = db.selectObjects?.(
-    `
+  const rows: StagingItemRow[] = [];
+  await db.exec({
+    sql: `
       SELECT *
       FROM staging_items
       ORDER BY createdAt DESC
-      LIMIT ? OFFSET ?;
+      LIMIT ?1 OFFSET ?2
     `,
-    [limit, offset]
-  ) as StagingItemRow[];
+    bind: [limit, offset],
+    rowMode: 'object',
+    callback: (row) => rows.push(row as StagingItemRow),
+  });
 
-  return rows ?? [];
+  return rows;
 }
 
 export async function discardStagingItem(id: number): Promise<void> {
-  const db = await getDb();
-  db.exec?.({
-    sql: `DELETE FROM staging_items WHERE id = ?;`,
+  const db = await getWriteAdapter();
+  await db.exec({
+    sql: `DELETE FROM staging_items WHERE id = ?1`,
     bind: [id],
   });
 }
 
-export async function fileStagingItem(id: number): Promise<void> {
-  const db = await getDb();
-
-  const rows = db.selectObjects?.(
-    `SELECT * FROM staging_items WHERE id = ?;`,
-    [id]
-  ) as StagingItemRow[];
-
-  if (!rows || rows.length === 0) return;
-  const item = rows[0];
-
-  // Use the same API NodesPage uses
-  await addNode(item.title ?? '(untitled)', item.content ?? undefined);
-
-  // Remove from staging
-  await discardStagingItem(id);
-}
-
 export async function updateStagingTags(id: number, tags: string[]): Promise<void> {
-  const db = await getDb();
-  db.exec?.({
-    sql: `UPDATE staging_items SET tags = ? WHERE id = ?;`,
+  const db = await getWriteAdapter();
+  await db.exec({
+    sql: `UPDATE staging_items SET tags = ?1 WHERE id = ?2`,
     bind: [JSON.stringify(tags), id],
   });
 }
 
 export async function updateStagingSummary(id: number, summary: string): Promise<void> {
-  const db = await getDb();
+  const db = await getWriteAdapter();
 
-  // Load current meta JSON (if any)
-  const rows = db.selectObjects?.(
-    `SELECT meta FROM staging_items WHERE id = ?;`,
-    [id]
-  ) as { meta: string | null }[];
-
+  // Load current meta JSON
   let meta: any = {};
-  if (rows && rows.length > 0 && rows[0].meta) {
+  const rows: { meta: string | null }[] = [];
+  await db.exec({
+    sql: `SELECT meta FROM staging_items WHERE id = ?1`,
+    bind: [id],
+    rowMode: 'object',
+    callback: (row) => rows.push(row as { meta: string | null }),
+  });
+
+  if (rows.length > 0 && rows[0].meta) {
     try {
       meta = JSON.parse(rows[0].meta);
     } catch {
@@ -119,11 +98,60 @@ export async function updateStagingSummary(id: number, summary: string): Promise
     }
   }
 
-  // Update summary
   meta.summary = summary;
 
-  db.exec?.({
-    sql: `UPDATE staging_items SET meta = ? WHERE id = ?;`,
+  await db.exec({
+    sql: `UPDATE staging_items SET meta = ?1 WHERE id = ?2`,
     bind: [JSON.stringify(meta), id],
   });
+}
+
+export async function updateStagingLinks(id: number, links: number[]): Promise<void> {
+  const db = await getWriteAdapter();
+
+  // Load current meta JSON
+  let meta: any = {};
+  const rows: { meta: string | null }[] = [];
+  await db.exec({
+    sql: `SELECT meta FROM staging_items WHERE id = ?1`,
+    bind: [id],
+    rowMode: 'object',
+    callback: (row) => rows.push(row as { meta: string | null }),
+  });
+
+  if (rows.length > 0 && rows[0].meta) {
+    try {
+      meta = JSON.parse(rows[0].meta);
+    } catch {
+      meta = {};
+    }
+  }
+
+  meta.links = links;
+
+  await db.exec({
+    sql: `UPDATE staging_items SET meta = ?1 WHERE id = ?2`,
+    bind: [JSON.stringify(meta), id],
+  });
+}
+
+export async function fileStagingItem(id: number): Promise<void> {
+  const db = await getDbAdapter();
+
+  const rows: StagingItemRow[] = [];
+  await db.exec({
+    sql: `SELECT * FROM staging_items WHERE id = ?1`,
+    bind: [id],
+    rowMode: 'object',
+    callback: (row) => rows.push(row as StagingItemRow),
+  });
+
+  if (rows.length === 0) return;
+  const item = rows[0];
+
+  // Insert into nodes using shared helper
+  await addNode(item.title ?? '(untitled)', item.content ?? undefined);
+
+  // Remove from staging
+  await discardStagingItem(id);
 }

--- a/apps/web/src/data/staging.ts
+++ b/apps/web/src/data/staging.ts
@@ -92,3 +92,12 @@ export async function fileStagingItem(id: number): Promise<void> {
   // Remove from staging
   await discardStagingItem(id);
 }
+
+export async function updateStagingTags(id: number, tags: string[]): Promise<void> {
+  const db = await getDb();
+  db.exec?.({
+    sql: `UPDATE staging_items SET tags = ? WHERE id = ?;`,
+    bind: [JSON.stringify(tags), id],
+  });
+}
+

--- a/apps/web/src/pages/NodesPage.tsx
+++ b/apps/web/src/pages/NodesPage.tsx
@@ -1,74 +1,26 @@
 // apps/web/src/pages/NodesPage.tsx
-import { useState } from 'react';
 import { useNodes } from '../hooks/useNodes';
-import { usePersistenceMode } from '../hooks/usePersistenceMode';
+import CaptureForm from '../components/CaptureForm';
+import PersistencePill from '../components/PersistencePill';
 
 export default function NodesPage() {
-  const [title, setTitle] = useState('');
-  const [body, setBody] = useState('');
   const { nodes, isLoading, isSubmitting, deletingId, error, add, remove } = useNodes();
-  const mode = usePersistenceMode();
-
-  async function onSubmit(e: React.FormEvent) {
-    e.preventDefault();
-    const t = title.trim();
-    const b = body.trim();
-    if (!t) return;
-    await add(t, b || undefined);
-    setTitle('');
-    setBody('');
-  }
-
-  const pillStyle: React.CSSProperties = {
-    padding: '2px 8px',
-    borderRadius: 999,
-    fontSize: 12,
-    border: '1px solid rgba(0,0,0,0.15)',
-    background: 'rgba(0,0,0,0.03)',
-  };
 
   return (
     <div style={{ padding: 16, maxWidth: 640 }}>
       <div style={{ display: 'flex', alignItems: 'baseline', justifyContent: 'space-between', marginBottom: 12 }}>
         <h1 style={{ margin: 0 }}>Nodes</h1>
         <div style={{ display: 'flex', gap: 8, alignItems: 'center' }}>
-          <span style={pillStyle}>
-            Persistence: {mode ?? '…'}
-          </span>
+          <PersistencePill />
         </div>
       </div>
 
-      {mode === 'memory' ? (
-        <div style={{ fontSize: 12, opacity: 0.75, marginBottom: 8 }}>
-          Data is in memory for now and will reset on reload. We’ll switch to OPFS persistence by moving SQLite into a Web Worker soon.
-        </div>
-      ) : null}
-
-      <form onSubmit={onSubmit} style={{ display: 'grid', gap: 8, marginBottom: 12 }}>
-        <input
-          type="text"
-          placeholder="Title…"
-          value={title}
-          onChange={(e) => setTitle(e.target.value)}
-          disabled={isSubmitting}
-          style={{ padding: 8 }}
-          aria-label="Node title"
-        />
-        <textarea
-          placeholder="Body (optional)…"
-          value={body}
-          onChange={(e) => setBody(e.target.value)}
-          disabled={isSubmitting}
-          rows={3}
-          style={{ padding: 8, resize: 'vertical' }}
-          aria-label="Node body"
-        />
-        <div style={{ display: 'flex', gap: 8 }}>
-          <button type="submit" disabled={isSubmitting || !title.trim()} style={{ padding: '8px 12px' }}>
-            {isSubmitting ? 'Adding…' : 'Add'}
-          </button>
-        </div>
-      </form>
+      <CaptureForm
+        onSubmit={async (title, body) => {
+          await add(title, body);
+        }}
+        disabled={isSubmitting}
+      />
 
       {error ? (
         <div role="alert" style={{ color: 'crimson', marginBottom: 12 }}>{error}</div>

--- a/apps/web/src/pages/NodesPage.tsx
+++ b/apps/web/src/pages/NodesPage.tsx
@@ -2,6 +2,7 @@
 import { useNodes } from '../hooks/useNodes';
 import CaptureForm from '../components/CaptureForm';
 import PersistencePill from '../components/PersistencePill';
+import NodeItem from '../components/NodeItem';
 
 export default function NodesPage() {
   const { nodes, isLoading, isSubmitting, deletingId, error, add, remove } = useNodes();
@@ -32,41 +33,17 @@ export default function NodesPage() {
         <div style={{ opacity: 0.7 }}>No nodes yet.</div>
       ) : (
         <ul style={{ listStyle: 'none', padding: 0, margin: 0, display: 'grid', gap: 8 }}>
-          {nodes.map((n) => {
-            const isDeleting = deletingId === n.id;
-            return (
-              <li
-                key={n.id}
-                style={{
-                  padding: 12,
-                  border: '1px solid rgba(0,0,0,0.1)',
-                  borderRadius: 8,
-                  display: 'grid',
-                  gap: 6,
-                }}
-              >
-                <div style={{ display: 'flex', alignItems: 'baseline', justifyContent: 'space-between', gap: 12 }}>
-                  <div style={{ minWidth: 0, flex: 1 }}>
-                    <div style={{ fontWeight: 600, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
-                      {n.title}
-                    </div>
-                    <div style={{ fontSize: 12, opacity: 0.7 }}>{n.createdAt.toLocaleString()}</div>
-                  </div>
-                  <button
-                    onClick={() => remove(n.id)}
-                    disabled={isDeleting}
-                    style={{ padding: '6px 10px' }}
-                    aria-label={`Delete ${n.title}`}
-                  >
-                    {isDeleting ? 'Deleting…' : 'Delete'}
-                  </button>
-                </div>
-                {n.body ? (
-                  <div style={{ whiteSpace: 'pre-wrap', wordBreak: 'break-word' }}>{n.body}</div>
-                ) : null}
-              </li>
-            );
-          })}
+          {nodes.map((n) => (
+            <NodeItem
+              key={n.id}
+              id={n.id}
+              title={n.title}
+              body={n.body ?? undefined}
+              createdAt={n.createdAt}
+              onDelete={remove}
+              isDeleting={deletingId === n.id}
+            />
+          ))}
         </ul>
       )}
     </div>

--- a/apps/web/src/pages/StagingPage.tsx
+++ b/apps/web/src/pages/StagingPage.tsx
@@ -5,6 +5,7 @@ import {
   listStagingItems,
   discardStagingItem,
   fileStagingItem,
+  updateStagingTags,
   type StagingItemRow,
 } from '../data/staging';
 import CaptureForm from '../components/CaptureForm';
@@ -42,6 +43,11 @@ export default function StagingPage() {
     await fileStagingItem(id);
     await refresh();
     setFilingId(null);
+  }
+
+  async function updateTags(id: number, tags: string[]) {
+    await updateStagingTags(id, tags);
+    await refresh();
   }
 
   return (
@@ -97,6 +103,7 @@ export default function StagingPage() {
               item={item}
               onDiscard={discard}
               onFile={fileItem}
+              onUpdateTags={updateTags}
               isDiscarding={discardingId === item.id}
               isFiling={filingId === item.id}
             />

--- a/apps/web/src/pages/StagingPage.tsx
+++ b/apps/web/src/pages/StagingPage.tsx
@@ -6,6 +6,7 @@ import {
   discardStagingItem,
   fileStagingItem,
   updateStagingTags,
+  updateStagingSummary,
   type StagingItemRow,
 } from '../data/staging';
 import CaptureForm from '../components/CaptureForm';
@@ -17,6 +18,7 @@ export default function StagingPage() {
   const [loading, setLoading] = useState(true);
   const [discardingId, setDiscardingId] = useState<number | null>(null);
   const [filingId, setFilingId] = useState<number | null>(null);
+  const [summarizingId, setSummarizingId] = useState<number | null>(null);
 
   async function refresh() {
     const rows = await listStagingItems({ limit: 50 });
@@ -48,6 +50,14 @@ export default function StagingPage() {
   async function updateTags(id: number, tags: string[]) {
     await updateStagingTags(id, tags);
     await refresh();
+  }
+
+  async function summarize(id: number) {
+    setSummarizingId(id);
+    // Placeholder summary for now
+    await updateStagingSummary(id, 'This is a placeholder summary.');
+    await refresh();
+    setSummarizingId(null);
   }
 
   return (
@@ -104,8 +114,10 @@ export default function StagingPage() {
               onDiscard={discard}
               onFile={fileItem}
               onUpdateTags={updateTags}
+              onSummarize={summarize}
               isDiscarding={discardingId === item.id}
               isFiling={filingId === item.id}
+              isSummarizing={summarizingId === item.id}
             />
           ))}
         </ul>

--- a/apps/web/src/pages/StagingPage.tsx
+++ b/apps/web/src/pages/StagingPage.tsx
@@ -1,0 +1,61 @@
+// apps/web/src/pages/StagingPage.tsx
+import { useEffect, useState } from 'react';
+import { listStagingItems, type StagingItemRow } from '../data/staging';
+
+export default function StagingPage() {
+  const [items, setItems] = useState<StagingItemRow[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let mounted = true;
+    listStagingItems({ limit: 50 })
+      .then((rows) => {
+        if (mounted) {
+          setItems(rows);
+          setLoading(false);
+        }
+      })
+      .catch((err) => {
+        console.error('Failed to load staging items:', err);
+        setLoading(false);
+      });
+    return () => {
+      mounted = false;
+    };
+  }, []);
+
+  return (
+    <div style={{ padding: 16, maxWidth: 640 }}>
+      <h1>Staging</h1>
+
+      {loading ? (
+        <div style={{ opacity: 0.7 }}>Loading…</div>
+      ) : items.length === 0 ? (
+        <div style={{ opacity: 0.7 }}>No staging items yet.</div>
+      ) : (
+        <ul style={{ listStyle: 'none', padding: 0, margin: 0, display: 'grid', gap: 8 }}>
+          {items.map((item) => (
+            <li
+              key={item.id}
+              style={{
+                padding: 12,
+                border: '1px solid rgba(0,0,0,0.1)',
+                borderRadius: 8,
+                display: 'flex',
+                flexDirection: 'column',
+                gap: 4,
+              }}
+            >
+              <div style={{ fontWeight: 600 }}>
+                {item.title || '(untitled)'}
+              </div>
+              <div style={{ fontSize: 12, opacity: 0.7 }}>
+                {item.kind} • {new Date(item.createdAt).toLocaleString()}
+              </div>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/pages/StagingPage.tsx
+++ b/apps/web/src/pages/StagingPage.tsx
@@ -1,32 +1,51 @@
 // apps/web/src/pages/StagingPage.tsx
 import { useEffect, useState } from 'react';
-import { listStagingItems, type StagingItemRow } from '../data/staging';
+import { insertStagingItem, listStagingItems, type StagingItemRow } from '../data/staging';
+import CaptureForm from '../components/CaptureForm';
+import PersistencePill from '../components/PersistencePill';
 
 export default function StagingPage() {
   const [items, setItems] = useState<StagingItemRow[]>([]);
   const [loading, setLoading] = useState(true);
 
+  async function refresh() {
+    const rows = await listStagingItems({ limit: 50 });
+    setItems(rows);
+    setLoading(false);
+  }
+
   useEffect(() => {
-    let mounted = true;
-    listStagingItems({ limit: 50 })
-      .then((rows) => {
-        if (mounted) {
-          setItems(rows);
-          setLoading(false);
-        }
-      })
-      .catch((err) => {
-        console.error('Failed to load staging items:', err);
-        setLoading(false);
-      });
-    return () => {
-      mounted = false;
-    };
+    refresh().catch((err) => {
+      console.error('Failed to load staging items:', err);
+      setLoading(false);
+    });
   }, []);
 
   return (
     <div style={{ padding: 16, maxWidth: 640 }}>
-      <h1>Staging</h1>
+      <div style={{ display: 'flex', alignItems: 'baseline', justifyContent: 'space-between', marginBottom: 12 }}>
+        <h1 style={{ margin: 0 }}>Staging</h1>
+        <div style={{ display: 'flex', gap: 8, alignItems: 'center' }}>
+          <PersistencePill />
+        </div>
+      </div>
+
+      <CaptureForm
+        titlePlaceholder="Title…"
+        bodyPlaceholder="Body (optional)…"
+        onSubmit={async (title, body) => {
+          await insertStagingItem({
+            kind: 'text',
+            title,
+            content: body ?? null,
+            filePath: null,
+            source: 'manual',
+            tags: null,
+            meta: null,
+          });
+          await refresh();
+        }}
+      />
 
       {loading ? (
         <div style={{ opacity: 0.7 }}>Loading…</div>
@@ -46,12 +65,13 @@ export default function StagingPage() {
                 gap: 4,
               }}
             >
-              <div style={{ fontWeight: 600 }}>
-                {item.title || '(untitled)'}
-              </div>
+              <div style={{ fontWeight: 600 }}>{item.title || '(untitled)'}</div>
               <div style={{ fontSize: 12, opacity: 0.7 }}>
                 {item.kind} • {new Date(item.createdAt).toLocaleString()}
               </div>
+              {item.content ? (
+                <div style={{ whiteSpace: 'pre-wrap', wordBreak: 'break-word' }}>{item.content}</div>
+              ) : null}
             </li>
           ))}
         </ul>

--- a/apps/web/src/workers/sqlite.worker.ts
+++ b/apps/web/src/workers/sqlite.worker.ts
@@ -1,9 +1,9 @@
 // apps/web/src/workers/sqlite.worker.ts
 import type { IpcRequest, IpcResponse } from '../data/ipc';
 
-let initPromise: Promise<void> | null = null;
 let sqlite3: any = null;
 let db: any = null;
+let initPromise: Promise<void> | null = null;
 let isReady = false;
 
 function post(msg: IpcResponse) {
@@ -26,6 +26,7 @@ async function ensureInit() {
 
     db = new OpfsDb('reginald.db');
 
+    // Ensure schema (nodes + staging_items)
     db.exec?.(`
       CREATE TABLE IF NOT EXISTS nodes (
         id INTEGER PRIMARY KEY,
@@ -35,9 +36,25 @@ async function ensureInit() {
       );
     `);
 
+    db.exec?.(`
+      CREATE TABLE IF NOT EXISTS staging_items (
+        id INTEGER PRIMARY KEY,
+        kind TEXT NOT NULL CHECK(kind IN ('text','file','url','clipboard')),
+        title TEXT,
+        content TEXT,
+        filePath TEXT,
+        source TEXT NOT NULL CHECK(source IN ('manual','dragdrop','clipboard','import')),
+        tags TEXT,
+        createdAt INTEGER NOT NULL,
+        meta TEXT
+      );
+    `);
+
+    db.exec?.(`CREATE INDEX IF NOT EXISTS idx_staging_items_createdAt ON staging_items(createdAt DESC);`);
+    db.exec?.(`CREATE INDEX IF NOT EXISTS idx_staging_items_kind ON staging_items(kind);`);
+
     isReady = true;
-    // eslint-disable-next-line no-console
-    console.info('[sqlite-worker] initialized with OPFS DB: reginald.db');
+    console.info('[sqlite-worker] OPFS DB opened and schema ensured');
   })();
 
   return initPromise;
@@ -82,9 +99,9 @@ self.addEventListener('message', async (ev: MessageEvent<IpcRequest>) => {
       }
       default: {
         post({
-          id: (msg as any)?.id ?? 'unknown',
+          id: msg.id,
           type: 'error',
-          error: `unknown message type: ${String((msg as any).type)}`,
+          error: `unknown message type: ${String(msg.type)}`,
         });
       }
     }

--- a/apps/web/src/workers/sqlite.worker.ts
+++ b/apps/web/src/workers/sqlite.worker.ts
@@ -99,9 +99,9 @@ self.addEventListener('message', async (ev: MessageEvent<IpcRequest>) => {
       }
       default: {
         post({
-          id: msg.id,
+          id: (msg as any)?.id ?? 'unknown',
           type: 'error',
-          error: `unknown message type: ${String(msg.type)}`,
+          error: `unknown message type: ${String((msg as any)?.type ?? 'undefined')}`,
         });
       }
     }


### PR DESCRIPTION
## Summary

Implements the Capture & Staging Area (Block C). Adds a new `staging_items` table in the Worker-backed OPFS database, with a StagingPage UI to capture, triage, and act on items. Includes support for Discard, File → Nodes, Tag, Link (inline UI), and a Summarize placeholder.

## Why

Nodes are meant to remain clean and minimal. The Staging Area provides a flexible space for capturing and experimenting with raw input before filing into Nodes. This separation supports future enrichment actions (summarization, linking, metadata) without cluttering Nodes.

## Test plan

- Start dev server (`pnpm dev`) and navigate to the app
- Add a new staging item via the Capture form
- Reload the app → staging items should persist in OPFS
- Verify each action:
  - **Discard** removes item from staging
  - **File** moves item to Nodes and deletes from staging
  - **Tag** allows inline add/remove of tags
  - **Link** shows a dropdown of existing Nodes and allows add/remove
  - **Summarize** inserts placeholder text
- Confirm Nodes still persist and remain unaffected by staging metadata

## Screenshots (if UI)

<!-- add before/after or staging view screenshots here -->

## Risk & rollback

- Risk: Worker schema drift if `sqlite.worker.ts` and `db.ts` diverge
- Risk: Early UI is functional but not styled; may change in Block D
- Rollback: Revert this commit; app will fall back to Nodes-only functionality

## Notes

- Prepares for Block D (UI/UX improvements)
- Follows trunk-based workflow; squash-merge into `main`
